### PR TITLE
Feature/header part

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,4 @@ These fonts have been chosen to align with the theme niche which is thematically
 - Custom Shadow 'LSX Shadow' for buttons
 - 'Dark Mode' style variation and color palette variation 
 - Lexend & Manrope variable fonts according to LSX Design System
+- 'LSX Header' template part following LSX Design System

--- a/parts/lsx-header.html
+++ b/parts/lsx-header.html
@@ -1,0 +1,15 @@
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"0.63rem","bottom":"0.63rem"}},"color":{"background":"#fefefe"}},"align":"full","layout":{"type":"default"}} -->
+	<div class="wp-block-group has-background alignfull" style="background-color:#fefefe;padding-top:0.63rem;padding-bottom:0.63rem">
+		<!-- wp:group {"layout":{"type":"constrained"}} -->
+		<div class="wp-block-group alignwide">
+			<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+			<div class="wp-block-group alignwide">
+				<!-- wp:site-logo /-->
+				<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
+				<div class="wp-block-group">
+					<!-- wp:navigation {"ref":5} /-->
+				</div><!-- /wp:group -->
+			</div><!-- /wp:group -->
+		</div><!-- /wp:group -->
+	</div>
+<!-- /wp:group -->

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"lsx-header"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">

--- a/theme.json
+++ b/theme.json
@@ -769,6 +769,11 @@
 			"title": "Header with large title"
 		},
 		{
+			"area": "header",
+			"name": "lsx-header",
+			"title": "LSX Header"
+		},
+		{
 			"area": "footer",
 			"name": "footer",
 			"title": "Footer"


### PR DESCRIPTION
Create a new header template part called `lsx-header` following the LSX Design System.
Includes: 
- Custom site logo 
- Simple navigation 
- Full width layout to align with current footer template

Registered in theme.json and updated `home.html `to include the header for demo purposes (remaining templates have not been updated yet) -> [custom_header_screengrab.pdf](https://github.com/user-attachments/files/21315065/custom_header_screengrab.pdf)
